### PR TITLE
Change Quill's external config to lower case

### DIFF
--- a/webpack.module.js
+++ b/webpack.module.js
@@ -26,7 +26,7 @@ export let common = {
   },
   target: 'web',
   externals: {
-    quill: "Quill",
+    quill: "quill",
   },
   plugins: [
     new MiniCssExtractPlugin({


### PR DESCRIPTION
We are trying to use this package in Angular and are seeing build errors when building on Linux:

```
node_modules/@windmillcode/quill-emoji/quill-emoji.js:1:19:
      1 │ import * as e from "Quill";
```

This seems to be because of the externals config in webpack.module - the package name is `quill`, and not `Quill`.